### PR TITLE
Fix cmake and install rviz_backdrop library.

### DIFF
--- a/rviz_backdrop/CMakeLists.txt
+++ b/rviz_backdrop/CMakeLists.txt
@@ -2,23 +2,19 @@
 # Catkin CMake Standard: http://www.ros.org/doc/groovy/api/catkin/html/user_guide/standards.html
 cmake_minimum_required(VERSION 2.8.3)
 project(rviz_backdrop)
+
 # Load catkin and all dependencies required for this package
-# TODO: remove all from COMPONENTS that are not catkin packages.
 find_package(catkin REQUIRED COMPONENTS rviz)
-
-# include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
-# CATKIN_MIGRATION: removed during catkin migration
-# cmake_minimum_required(VERSION 2.4.6)
-
-# CATKIN_MIGRATION: removed during catkin migration
-# include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
-set(ROS_BUILD_TYPE RelWithDebInfo)
-
-# CATKIN_MIGRATION: removed during catkin migration
-# rosbuild_init()
 
 find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
 include(${QT_USE_FILE})
+
+# catkin_package parameters: http://ros.org/doc/groovy/api/catkin/html/dev_guide/generated_cmake_api.html#catkin-package
+catkin_package(
+    CATKIN_DEPENDS rviz
+    INCLUDE_DIRS # TODO include
+    LIBRARIES # TODO
+)
 
 include_directories(${rviz_INCLUDE_DIRS})
 
@@ -29,9 +25,6 @@ add_definitions(-DQT_NO_KEYWORDS)
 set(SOURCE_FILES
   src/backdrop_display.cpp
 )
-
-## Set the default path for built libraries to the "lib" directory
-set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
 ## An rviz plugin is just a shared library, so here we declare the
 ## library to be called ``${PROJECT_NAME}`` (which is
@@ -50,20 +43,13 @@ add_library(${PROJECT_NAME} ${SOURCE_FILES})
 ## particular OS.
 target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES})
 
-## Generate added messages and services with any dependencies listed here
-#generate_messages(
-#    #TODO DEPENDENCIES geometry_msgs std_msgs
-#)
+# install the library
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 
-# catkin_package parameters: http://ros.org/doc/groovy/api/catkin/html/dev_guide/generated_cmake_api.html#catkin-package
-# TODO: fill in what other packages will need to use this package
-catkin_package(
-    DEPENDS rviz
-    CATKIN_DEPENDS # TODO
-    INCLUDE_DIRS # TODO include
-    LIBRARIES # TODO
-)
-
+# install the plugin description
 install(FILES
   plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
Fix the ordering of the cmake commands so that the rviz_backdrop library builds in the correct location, and supply an install rule for it.

This only fixes part of #3 
