### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/rviz_backdrop/src/backdrop_display.cpp
+++ b/rviz_backdrop/src/backdrop_display.cpp
@@ -281,5 +281,5 @@ void BackdropDisplay::createProperties()
 // Tell pluginlib about this class.  It is important to do this in
 // global scope, outside our package's namespace.
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS( rviz_backdrop, Backdrop, rviz_backdrop::BackdropDisplay, rviz::Display )
+PLUGINLIB_EXPORT_CLASS(rviz_backdrop::BackdropDisplay, rviz::Display)
 // END_TUTORIAL


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions